### PR TITLE
Support current draw API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,10 @@ Wemo.Switch.off?(living_room)
 Wemo.Switch.status(living_room)
 => 1
 ```
+
+Checking the current draw of a switch (for switches like WeMo Insight that support this functionality):
+
+```elixir-lang
+Wemo.Switch.current_draw(living_room)
+=> 92170
+```

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Turning a switch on and off:
 
 ```elixir-lang
 living_room = Wemo.Switch.find_by_name("Living Room")
-Switch.on(living_room)
+Wemo.Switch.on(living_room)
 => {:ok, 1}
 
-Switch.off(living_room)
+Wemo.Switch.off(living_room)
 => {:ok, 0}
 ```
 

--- a/lib/wemo/switch.ex
+++ b/lib/wemo/switch.ex
@@ -7,6 +7,7 @@ defmodule Wemo.Switch do
   alias Wemo.Switch.Discovery
   alias Wemo.Switch.QueryStatus
   alias Wemo.Switch.ChangeStatus
+  alias Wemo.Switch.QueryCurrentDraw
   alias Wemo.Switch.Metadata
 
   @doc """
@@ -61,6 +62,17 @@ defmodule Wemo.Switch do
   @spec status(Wemo.Switch.Metadata) :: 0|1
   def status(switch) do
     QueryStatus.status(switch)
+  end
+
+  @doc """
+    Checks and returns the current draw of the supplied switch in milliwatts. For example:
+
+      iex> Wemo.Switch.find_by_name("WeMo Switch") |> Wemo.Switch.current_draw
+      92170
+  """
+  @spec current_draw(Wemo.Switch.Metadata) :: integer
+  def current_draw(switch) do
+    QueryCurrentDraw.current_draw(switch)
   end
 
   defp set_state(state, %Metadata{}=switch) when state in [0, 1] do

--- a/lib/wemo/switch/client/mock_soap_client.ex
+++ b/lib/wemo/switch/client/mock_soap_client.ex
@@ -33,4 +33,18 @@ defmodule Wemo.Switch.Client.MockSoapClient do
 
     body
   end
+
+  def post_request(_xml, url, "urn:Belkin:service:insight:1#GetPower)") do
+    filename = case url do
+      "http://192.168.1.100" <> _remaining ->
+        "current_draw_check_response.xml"
+      _ ->
+        "state_change_error_response.xml"
+    end
+
+    {:ok, body} = Path.join(@xml_dir, filename)
+    |> File.read
+
+    body
+  end
 end

--- a/lib/wemo/switch/query_current_draw.ex
+++ b/lib/wemo/switch/query_current_draw.ex
@@ -1,0 +1,37 @@
+defmodule Wemo.Switch.QueryCurrentDraw do
+  import SweetXml
+
+  @soap_client Application.get_env(:wemo, :soap_client,Wemo.Switch.Client.SoapClient)
+
+  @spec current_draw(Wemo.Switch.Metadata) :: integer
+  def current_draw(switch) do
+    state = build_current_draw_query_xml()
+    |> post_current_draw_query_request(switch)
+    |> parse_current_draw_query_response
+
+    state
+  end
+
+  defp build_current_draw_query_xml do
+    """
+    <?xml version="1.0" encoding="utf-8"?>
+    <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <s:Body>
+    <u:GetPower xmlns:u="urn:Belkin:service:insight:1"/>
+    </s:Body>
+    </s:Envelope>
+    """
+  end
+
+  defp post_current_draw_query_request(xml, switch) do
+    @soap_client.post_request(
+      xml,
+      "#{switch.base_url}/upnp/control/insight1",
+      "urn:Belkin:service:insight:1#GetPower)"
+    )
+  end
+
+  defp parse_current_draw_query_response(response_body) do
+    xpath(response_body, ~x"//s:Envelope/s:Body/u:GetPowerResponse/InstantPower/text()"i)
+  end
+end

--- a/test/fixtures/xml/current_draw_check_response.xml
+++ b/test/fixtures/xml/current_draw_check_response.xml
@@ -1,0 +1,7 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+  <s:Body>
+    <u:GetPowerResponse xmlns:u="urn:Belkin:service:insight:1">
+      <InstantPower>92170</InstantPower>
+    </u:GetPowerResponse>
+  </s:Body>
+</s:Envelope>

--- a/test/wemo/switch/query_current_draw_test.exs
+++ b/test/wemo/switch/query_current_draw_test.exs
@@ -1,0 +1,16 @@
+defmodule Wemo.Switch.QueryCurrentDrawTest do
+  use ExUnit.Case, async: true
+
+  alias Wemo.Switch.QueryCurrentDraw
+
+  describe "QueryCurrentDrawTest.current_draw/1" do
+    test "returns the current draw" do
+      switch = %Wemo.Switch.Metadata{
+        base_url: "http://192.168.1.100",
+        friendly_name: "Lounge"
+      }
+
+      assert QueryCurrentDraw.current_draw(switch) == 92170
+    end
+  end
+end

--- a/test/wemo/switch_test.exs
+++ b/test/wemo/switch_test.exs
@@ -64,4 +64,15 @@ defmodule Wemo.SwitchTest do
       assert Switch.off(switch) == {:no_change, 0}
     end
   end
+
+  describe "Switch.current_draw/1" do
+    test "returns the current draw" do
+      switch = %Wemo.Switch.Metadata{
+        friendly_name: "WeMo Switch",
+        base_url: "http://192.168.1.100"
+      }
+
+      assert Switch.current_draw(switch) == 92170
+    end
+  end
 end


### PR DESCRIPTION
Based on https://www.chameth.com/2016/05/02/monitoring-power-with-wemo/, need to do a live test before merging.

Need to confirm that current draw response is an integer rather than float. Perhaps safest to treat it as a float.